### PR TITLE
Update Certificate.md

### DIFF
--- a/Certificate.md
+++ b/Certificate.md
@@ -1,3 +1,66 @@
+
+{
+    "name": "My certificate for example.com",
+    "matches": ["https://example.com/*"],
+    "key": { "src": "/path/to/key" },
+    "cert": { "src": "/User/path/to/certificate" },
+    "passphrase": "iampassphrase"
+}
+var Collection = require('postman-collection').Collection,
+    mycollection;
+
+// create a blank collection
+myCollection = new Collection();
+myCollection.describe('Hey! This is a cool collection.');
+
+console.log(myCollection.description.toString()); // read the description
+findInParents
+An example set operation would look like - ['foo', 1]
+
+If we break this down
+
+sample.mutations = [['foo', 1]]
+  |                     |___|_______ Key Path
+  |                         |_______ Value
+  |_________________________________ Target
+You would have noticed that the instruction is not explicitly captured. That's because it is derived from the parameter set.
+
+For example an unset operation would look like ['foo'].
+
+Which means you can derive the instruction based on the shape of the mutation itself. A mutation with single parameter would imply an unset operation. A mutation with two parameters would imply a set operation.
+
+Mutation tracking in Variable Scopes
+To track mutations in a Postman Variable Scope, you can enabled it like
+
+var VariableScope = require('postman-collection').VariableScope,
+    environment = new VariableScope();
+
+// enables tracking mutations
+environment.enableTracking();
+From this point onwards any set/unset/clear operations on environment will be captured in in environment.mutations.
+
+You can then apply the same mutation on a different object like
+
+var environmentCopy = new VariableScope();
+
+// applies the mutations captured on `environment` into `environmentCopy` making it a mirror
+environment.mutations.applyOn(environmentCopy);
+Limitations and scope for extension
+Postman collection SDK supports tracking mutations on VariableScopes. We could apply the same concepts to any type of object not restricted to a VariableScope.
+
+In practise more complex types would have complex instructions that are not restricted to set/unset. To capture those we might have to extend our representation for a mutation to support more complex instructions.
+
+We will have to capture the instruction explicitly in that case. To do so we can think of something like
+
+['id', 'addRequest', '#', '1', 'request1']
+   |________|_________|____|________|___________ Mutation Id
+            |_________|____|________|___________ Instruction
+                      |____|________|___________ Delimiter to differentiate from first generation mutations
+                           |________|___________ Key Path
+                                    |___________ Value
+
+
+
 var Certificate = require('postman-collection').Certificate,
    certificate = new Certificate({
     name: 'Certificate for example.com',


### PR DESCRIPTION
An example set operation would look like - ['foo', 1]

If we break this down

sample.mutations = [['foo', 1]]
  |                     |___|_______ Key Path
  |                         |_______ Value
  |_________________________________ Target
You would have noticed that the instruction is not explicitly captured. That's because it is derived from the parameter set.

For example an unset operation would look like ['foo'].

Which means you can derive the instruction based on the shape of the mutation itself. A mutation with single parameter would imply an unset operation. A mutation with two parameters would imply a set operation.

Mutation tracking in Variable Scopes
To track mutations in a Postman Variable Scope, you can enabled it like

var VariableScope = require('postman-collection').VariableScope,
    environment = new VariableScope();

// enables tracking mutations
environment.enableTracking();
From this point onwards any set/unset/clear operations on environment will be captured in in environment.mutations.

You can then apply the same mutation on a different object like

var environmentCopy = new VariableScope();

// applies the mutations captured on `environment` into `environmentCopy` making it a mirror environment.mutations.applyOn(environmentCopy);
Limitations and scope for extension
Postman collection SDK supports tracking mutations on VariableScopes. We could apply the same concepts to any type of object not restricted to a VariableScope.

In practise more complex types would have complex instructions that are not restricted to set/unset. To capture those we might have to extend our representation for a mutation to support more complex instructions.

We will have to capture the instruction explicitly in that case. To do so we can think of something like

['id', 'addRequest', '#', '1', 'request1']
   |________|_________|____|________|___________ Mutation Id
            |_________|____|________|___________ Instruction
                      |____|________|___________ Delimiter to differentiate from first generation mutations
                           |________|___________ Key Path
                                    |___________ Value